### PR TITLE
Changing from darwin to macos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,8 +38,8 @@ nix-dry:
     - nix-build -v -v --dry-run ./release.nix --attr package.linux.ia32.deb
     - nix-build -v -v --dry-run ./release.nix --attr package.windows.x64.exe
     - nix-build -v -v --dry-run ./release.nix --attr package.windows.ia32.exe
-    - nix-build -v -v --dry-run ./release.nix --attr package.darwin.x64.zip
-    - nix-build -v -v --dry-run ./release.nix --attr package.darwin.arm64.zip
+    - nix-build -v -v --dry-run ./release.nix --attr package.macos.x64.zip
+    - nix-build -v -v --dry-run ./release.nix --attr package.macos.arm64.zip
 
 nix:
   stage: build
@@ -67,8 +67,8 @@ packages:
           --attr package.linux.ia32.deb \
           --attr package.windows.x64.exe \
           --attr package.windows.ia32.exe \
-          --attr package.darwin.x64.zip \
-          --attr package.darwin.arm64.zip)";
+          --attr package.macos.x64.zip \
+          --attr package.macos.arm64.zip)";
         commit="$(git rev-parse --short HEAD)";
         gh release \
           create "$commit" $builds \

--- a/release.nix
+++ b/release.nix
@@ -96,7 +96,7 @@ let
     };
   buildZip = arch:
     stdenv.mkDerivation rec {
-      name = "${utils.basename}-${version}-darwin-${arch}.zip";
+      name = "${utils.basename}-${version}-macos-${arch}.zip";
       version = utils.node2nixDev.version;
       src = "${utils.node2nixDev}/lib/node_modules/${utils.node2nixDev.packageName}";
       buildInputs = [
@@ -154,7 +154,7 @@ in
           exe = buildExe "ia32";
         };
       };
-      darwin = {
+      macos = {
         x64 = {
           zip = buildZip "x64";
         };

--- a/utils.nix
+++ b/utils.nix
@@ -50,7 +50,6 @@ rec {
       npm install
     '';
   });
-  electronVersion = "12.0.9";
   electronBuilds = {
     "12.0.9" = {
       "linux-x64" = fetchurl {
@@ -81,7 +80,7 @@ rec {
   };
   electronZipDir =
     let
-      electronBuild = electronBuilds."${electronVersion}";
+      electronBuild = electronBuilds."12.0.9";
     in
       linkFarm "electron-zip-dir"
         [


### PR DESCRIPTION
It's silly to call what we are building darwin, it's really macos.

Also matches behaviour with https://github.com/MatrixAI/TypeScript-Demo-Lib/pull/25